### PR TITLE
WIP: Change to simplify thread interactions

### DIFF
--- a/octoprint_automation_scripts/__init__.py
+++ b/octoprint_automation_scripts/__init__.py
@@ -197,36 +197,21 @@ class MecodePlugin(octoprint.plugin.EventHandlerPlugin,
 
     def readline(self, *args, **kwargs):
         future = self.future_serial.future_readline(*args, **kwargs)
-        # Block until a result is set.
-        result = self._wait(future)
+        # Block until a result is set.  If there was an exception, raise it.
+        result = future.result()
         return result
 
     def write(self, data):
         future = self.future_serial.future_write(data)
-        # Block until a result is set.
-        result = self._wait(future)
+        # Block until a result is set.  If there was an exception, raise it.
+        result = future.result()
         return result
 
     def close(self):
         future = self.future_serial.future_close()
-        # Block until a result is set.
-        result = self._wait(future)
+        # Block until a result is set.  If there was an exception, raise it.
+        result = future.result()
         return result
-
-    def _wait(self, future):
-        """
-        Wait for a future to complete and return the result.  If it had an
-        exception, raise the exception.
-        """
-        for f in as_completed([future]):
-            if f.done() and not f.cancelled():
-                return f.result()
-            elif f.cancelled():
-                # We're never cancelling futures, so this should never happen.
-                raise RuntimeError("Future was unexpectedly cancelled")
-            else:
-                # There was an error in the worker.  Raise the exception here.
-                raise f.exception(0.1)
 
     ## Plugin Hooks  ###########################################################
 

--- a/octoprint_automation_scripts/__init__.py
+++ b/octoprint_automation_scripts/__init__.py
@@ -71,11 +71,11 @@ class MecodePlugin(octoprint.plugin.EventHandlerPlugin,
     def _start_work_threads(self):
         if hasattr(self, '_logger'):
             self._logger.debug('Starting work threads...')
-        self._read_thread = Thread(target=self.future_serial.work_off_reads,
+        self._read_thread = Thread(target=self._reads_entrypoint,
                                    name='octoprint_automation_scripts_reads')
         self._read_thread.daemon = True
         self._read_thread.start()
-        self._write_thread = Thread(target=self.future_serial.work_off_writes,
+        self._write_thread = Thread(target=self._writes_entrypoint,
                                     name='octoprint_automation_scripts_writes')
         self._write_thread.daemon = True
         self._write_thread.start()
@@ -84,6 +84,18 @@ class MecodePlugin(octoprint.plugin.EventHandlerPlugin,
         if hasattr(self, '_logger'):
             self._logger.debug('Stopping work threads...')
         self.future_serial.exit_work_threads(wait=True)
+
+    def _reads_entrypoint(self):
+        try:
+            self.future_serial.work_off_reads()
+        except Exception as e:
+            self._logger.exception('Error while running read work thread: ' + str(e))
+
+    def _writes_entrypoint(self):
+        try:
+            self.future_serial.work_off_writes()
+        except Exception as e:
+            self._logger.exception('Error while running write work thread: ' + str(e))
 
     ## MecodePlugin Interface  ##########################################
 

--- a/octoprint_automation_scripts/future_serial.py
+++ b/octoprint_automation_scripts/future_serial.py
@@ -1,7 +1,7 @@
-from concurrent.futures import Future, as_completed
-from Queue import Queue
+import concurrent.futures as futures
+import Queue as queue
 import sys
-from threading import Condition, Thread, Event, Lock
+import threading
 
 class QueueMessage:
 
@@ -19,14 +19,14 @@ class FutureSerial:
     """
 
     def __init__(self):
-        self.has_serial_event = Event()
+        self.has_serial_event = threading.Event()
         self._serial = None
 
         # Since a serial port can be read from and written to simultaneously, we
         # have two separate queues.  Queue implementations are assumed to be
         # thread-safe.
-        self.read_queue = Queue()
-        self.write_queue = Queue()
+        self.read_queue = queue.Queue()
+        self.write_queue = queue.Queue()
 
         # These flags are a way to terminate the worker threads.  Set them to
         # True from another thread to make the work loop exit.
@@ -53,7 +53,7 @@ class FutureSerial:
 
         This can safely be called from any number of threads.
         """
-        future = Future()
+        future = futures.Future()
         message = QueueMessage(future, 'readline', args, kwargs)
         self.read_queue.put(message)
         return future
@@ -65,7 +65,7 @@ class FutureSerial:
 
         This can safely be called from any number of threads.
         """
-        future = Future()
+        future = futures.Future()
         message = QueueMessage(future, 'write', [data])
         self.write_queue.put(message)
         return future
@@ -77,7 +77,7 @@ class FutureSerial:
 
         This can safely be called from any number of threads.
         """
-        future = Future()
+        future = futures.Future()
         message = QueueMessage(future, 'close', [])
         self.write_queue.put(message)
         return future

--- a/octoprint_automation_scripts/future_serial.py
+++ b/octoprint_automation_scripts/future_serial.py
@@ -3,7 +3,7 @@ import Queue as queue
 import sys
 import threading
 
-class QueueMessage:
+class QueueMessage(object):
 
     def __init__(self, future, message_type, args, kwargs = None):
         self.future = future
@@ -12,7 +12,7 @@ class QueueMessage:
         self.kwargs = kwargs
 
 
-class FutureSerial:
+class FutureSerial(object):
     """
     A proxy for a Serial object that returns Futures and executes `readline()`,
     `write()`, and `close()` in another thread instead of the calling thread.

--- a/octoprint_automation_scripts/future_serial.py
+++ b/octoprint_automation_scripts/future_serial.py
@@ -117,13 +117,13 @@ class FutureSerial(object):
         # Wait until we actually have a serial object set.
         self.has_serial_event.wait()
 
-        while not getattr(self, done_flag):
+        while True:
             # Pop work off the queue in FIFO order.  Block until we get
             # something.
             message = queue.get()
 
-            # If we see an exit message, stop looping.
-            if message.message_type == 'exit':
+            # If the done flag was set or we see an exit message, stop looping.
+            if getattr(self, done_flag) or message.message_type == 'exit':
                 break
 
             # Execute the message.

--- a/octoprint_automation_scripts/future_serial.py
+++ b/octoprint_automation_scripts/future_serial.py
@@ -41,7 +41,7 @@ class FutureSerial(object):
     def serial(self, serial):
         self._serial = serial
         # Signal to the worker thread that we have a serial object.
-        if self._serial:
+        if self._serial is not None:
             self.has_serial_event.set()
         else:
             self.has_serial_event.clear()

--- a/octoprint_automation_scripts/future_serial.py
+++ b/octoprint_automation_scripts/future_serial.py
@@ -1,0 +1,156 @@
+from concurrent.futures import Future, as_completed
+from threading import Thread, Event, Lock
+
+class QueueMessage:
+
+    def __init__(self, future, message_type, args, kwargs = None):
+        self.future = future
+        self.message_type = message_type
+        self.args = args
+        self.kwargs = kwargs
+
+
+class AtomicQueue:
+
+    def __init__(self):
+        self.queue = []
+        self.queue_lock = Lock()
+        self.has_payload_event = Event()
+
+    def append(payload):
+        with self.queue_lock:
+            self.queue.append(payload)
+            self.has_payload_event.set()
+
+    def popleft(self):
+        # If the queue is empty, yield to the OS until we have payload.
+        if not self.queue:
+            self.has_payload_event.wait()
+
+        with self.queue_lock:
+            payload = self.queue.popleft()
+            # If we've popped off the last payload, clear the event so we can
+            # get signaled in the future.  This must be done while holding
+            # the queue lock.
+            if not self.queue:
+                self.has_payload_event.clear()
+
+            return payload
+
+class FutureSerial:
+    """
+    A proxy for a Serial object that returns Futures and executes `readline()`,
+    `write()`, and `close()` in another thread instead of the calling thread.
+    """
+
+    def __init__(self):
+        self.has_serial_event = Event()
+        self._serial = None
+
+        # Since a serial port can be read from and written to simultaneously, we
+        # have two separate queues.
+        self.read_queue = AtomicQueue()
+        self.write_queue = AtomicQueue()
+
+        # These flags are a way to terminate the worker threads.  Set them to
+        # True from another thread to make the work loop exit.
+        self.done_reading = False
+        self.done_writing = False
+
+    @property
+    def serial(self):
+        return self._serial
+
+    @serial.setter
+    def serial(self, serial):
+        self._serial = serial
+        # Signal to the worker thread that we have a serial object.
+        if self._serial:
+            self.has_serial_event.set()
+        else:
+            self.has_serial_event.clear()
+
+    def future_readline(self, *args, **kwargs):
+        """
+        Returns a future that resolves to the result of readline() on the serial
+        object.
+
+        This can safely be called from any number of threads.
+        """
+        future = Future()
+        message = QueueMessage(future, 'readline', args, kwargs)
+        self.read_queue.append(message)
+        return future
+
+    def future_write(self, data):
+        """
+        Returns a future that resolves to the result of write() on the serial
+        object.
+
+        This can safely be called from any number of threads.
+        """
+        future = Future()
+        message = QueueMessage(future, 'write', [data])
+        self.write_queue.append(message)
+        return future
+
+    def future_close(self):
+        """
+        Returns a future that resolves to the result of close() on the serial
+        object.
+
+        This can safely be called from any number of threads.
+        """
+        future = Future()
+        message = QueueMessage(future, 'close', [])
+        self.write_queue.append(message)
+        return future
+
+    def work_off_reads(self):
+        """
+        Work off the read queue.
+
+        This should only be called from a single thread.
+        """
+        self._work_off(self.read_queue, 'done_reading')
+
+    def work_off_writes(self):
+        """
+        Work off the write queue.
+
+        This should only be called from a single thread.
+        """
+        self._work_off(self.write_queue, 'done_writing')
+
+    def _work_off(self, atomic_queue, done_flag):
+        # Wait until we actually have a serial object set.
+        self.has_serial_event.wait()
+
+        while not getattr(self, done_flag):
+            # Pop work off the queue in FIFO order.
+            message = atomic_queue.popleft()
+
+            # Execute the message.
+            self._run(message)
+
+    def _run(self, message):
+        """
+        Actually execute a message
+        """
+        if message.message_type == 'readline':
+            return self._readline(*message.args, **message.kwargs)
+        elif message.message_type == 'write':
+            return self._write(*message.args)
+        elif message.message_type == 'close':
+            return self._close(*message.args)
+        else:
+            raise RuntimeError('Unknown message type: {}'.format(message.message_type))
+
+    def _readline(self, *args, **kwargs):
+        return self.serial.single_threaded_readline(*args, **kwargs)
+
+    def _write(self, data):
+        return self.serial.single_threaded_write(data)
+
+    def _close(self):
+        return self.serial.single_threaded_close()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ plugin_author_email = "jack@voxel8.co"
 plugin_url = "https://github.com/Voxel8/OctoPrint-Automation-Scripts"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['numpy', 'mecode']
+plugin_requires = ['numpy', 'mecode', 'futures']
 
 # Additional package data to install for this plugin. The subfolders "templates", "static" and "translations" will
 # already be installed automatically if they exist.


### PR DESCRIPTION
Blocked actual testing by Voxel8/printer-automation#1.

This pull request decouples the thread(s) that OctoPrint calls the serial object with from the threads that actually read and write to the serial object.  This otherwise preserves functionality.

The downside is that this adds 2 more threads.  In addition to OctoPrint's threads, there are now:
- mecode print
- mecode read
- octoprint_automation_scripts mecode
- octoprint_automation_scripts reads (new)
- octoprint_automation_scripts writes (new)
